### PR TITLE
Config, querystrings, PATCH, other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/http-console
+++ b/bin/http-console
@@ -29,8 +29,8 @@ var argv = process.argv.slice(2), args = [],
         verbose:         false
     };
 
-while (arg = argv.shift()) {
-    if (option = arg.match(/^--?([\w-]+)$/)) {
+while ((arg = argv.shift())) {
+    if ((option = arg.match(/^--?([\w-]+)$/))) {
         switch (option[1]) {
             case 'cookies':
                 options.rememberCookies = true;

--- a/bin/http-console
+++ b/bin/http-console
@@ -13,6 +13,7 @@ var help = [
   '-v, --verbose      print requests',
   '    --json         set "Content-Type" header to application/json',
   '    --notimeout    don\'t timeout requests',
+  '-c, --config       config file, executed on startup',
   '    --ssl          create a secure connection',
   '    --version      print version',
   '-h, --help         display this message'
@@ -52,6 +53,10 @@ while (arg = argv.shift()) {
                 break;
             case 'notimeout':
                 options.timeout = false;
+                break;
+            case 'c':
+            case 'config':
+                options.configFile = argv.shift();
                 break;
             case 'h':
             case 'help':

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -210,7 +210,7 @@ this.Console.prototype = new(function () {
             path    = this.path.slice(0);
 
             if (command.length > 0) {
-              parts = command[0].split("?");
+              parts = command.join(" ").split("?");
               if (parts[0]) {
                 path.push(parts[0]);
               }

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -191,7 +191,7 @@ this.Console.prototype = new(function () {
             } else {
                 delete(this.headers[match[1]]);
             }
-        } else if (/^(GET|POST|PUT|HEAD|DELETE)/i.test(command)) {
+        } else if (/^(GET|POST|PUT|PATCH|HEAD|DELETE)/i.test(command)) {
             command = command.split(/\s+/);
             method  = command.shift().toUpperCase();
             path    = this.path.slice(0);
@@ -209,7 +209,7 @@ this.Console.prototype = new(function () {
               path += '?' + parts[1];
             }
 
-            if (method === 'PUT' || method === 'POST') {
+            if (method === 'PATCH' || method === 'PUT' || method === 'POST') {
                 this.pending = { method: method, path: path };
                 this.dataPrompt();
             } else {

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -15,6 +15,8 @@ try {
     var inspect = function (obj) { util.puts(util.inspect(obj).white) }
 }
 
+var TEST_HTTP_METHODS = /^(GET|POST|PUT|PATCH|HEAD|DELETE)/i;
+
 var consoles = [];
 
 this.Console = function (host, port, options) {
@@ -44,6 +46,15 @@ this.Console.prototype = new(function () {
         if (this.options.auth) {
             this.headers['Authorization'] = "Basic " +
                 new(Buffer)(this.options.auth.username + ':' + this.options.auth.password).toString('base64');
+        }
+
+        if (this.options.configFile) {
+            fs.readFileSync(this.options.configFile, "utf8").split(/\r\n|\n/).forEach(function (cmd) {
+                cmd = cmd.trim();
+                if (!TEST_HTTP_METHODS.test(cmd)) {
+                    that.exec(cmd);
+                }
+            });
         }
 
         this.readline = readline.createInterface(process.stdin, process.stdout);
@@ -191,7 +202,7 @@ this.Console.prototype = new(function () {
             } else {
                 delete(this.headers[match[1]]);
             }
-        } else if (/^(GET|POST|PUT|PATCH|HEAD|DELETE)/i.test(command)) {
+        } else if (TEST_HTTP_METHODS.test(command)) {
             command = command.split(/\s+/);
             method  = command.shift().toUpperCase();
             path    = this.path.slice(0);
@@ -261,6 +272,8 @@ this.Console.prototype = new(function () {
         }
     };
     this.prompt = function () {
+        if (!this.readline) { return; }
+
         var protocol = this.options.useSSL ? 'https://' : 'http://',
             path     = '/' + this.path.join('/'),
             host     = this.host + ':' + this.port,

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -77,6 +77,10 @@ this.Console.prototype = new(function () {
 
         if (this.options.verbose) {
             util.puts('> ' + (method + ' ' + path).grey);
+            Object.keys(headers).forEach(function (name) {
+                util.puts((name + ': ' + headers[name]).grey);
+            });
+            util.puts('');
         }
 
         this.setCookies(headers);
@@ -128,6 +132,12 @@ this.Console.prototype = new(function () {
                     that.prompt();
                 });
             });
+
+            if (this.options.verbose) {
+                util.puts(('' + command).grey);
+                util.puts('');
+            }
+
             req.write(command);
             req.end();
 

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -313,8 +313,7 @@ this.Console.prototype = new(function () {
     };
 });
 
-this.version = fs.readFileSync(require('path').join(__dirname, '..', 'package.json'))
-                 .toString().match(/"version"\s*:\s*"([\d.]+)"/)[1];
+this.version = JSON.parse(fs.readFileSync(require('path').join(__dirname, '..', 'package.json'))).version;
 
 this.help = [
     '.h[eaders]  ' +  'show active request headers.'.grey,

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -12,7 +12,7 @@ require('./ext');
 try {
     var inspect = require('eyes').inspector();
 } catch (e) {
-    var inspect = function (obj) { util.puts(util.inspect(obj).white) }
+    inspect = function (obj) { util.puts(util.inspect(obj).white); };
 }
 
 var TEST_HTTP_METHODS = /^(GET|POST|PUT|PATCH|HEAD|DELETE)/i;
@@ -21,7 +21,7 @@ var consoles = [];
 
 this.Console = function (host, port, options) {
     this.host = host;
-    this.port = parseInt(port);
+    this.port = parseInt(port, 10);
     this.options = options;
     this.timeout = this.options.timeout ? 5000 : 0;
     this.path = [];
@@ -81,7 +81,7 @@ this.Console.prototype = new(function () {
 
         this.headers['Host'] = this.host;
 
-        for (var k in this.headers) { headers[k] = this.headers[k] }
+        for (var k in this.headers) { headers[k] = this.headers[k]; }
 
         method = method.toUpperCase();
         path   = encodeURI(path);
@@ -107,9 +107,9 @@ this.Console.prototype = new(function () {
 
             res.setEncoding('utf8');
 
-            if (that.options.rememberCookies) { that.rememberCookies(res.headers) }
-            res.on('data', function (chunk) { body += chunk });
-            res.on('end',  function ()      { callback(res, body) });
+            if (that.options.rememberCookies) { that.rememberCookies(res.headers); }
+            res.on('data', function (chunk) { body += chunk; });
+            res.on('end',  function ()      { callback(res, body); });
         }).on('error', function (e) {
             util.error(e.toString().red);
             that.prompt();
@@ -135,6 +135,7 @@ this.Console.prototype = new(function () {
             that = this,
             match, req;
 
+        var prompt = true;
         if (this.pending) {
             req = this.request(this.pending.method, this.pending.path, {
                 'Content-Length' : command.length
@@ -152,7 +153,8 @@ this.Console.prototype = new(function () {
             req.write(command);
             req.end();
 
-            return this.pending = null;
+            this.pending = null;
+            prompt = false;
         } else if (command[0] === '/') {
             if (command === '//') {
                 this.path = [];
@@ -196,7 +198,7 @@ this.Console.prototype = new(function () {
             }
         } else if (command[0] === '\\') {
             this.exec(command.replace(/^\\/, '.'));
-        } else if (match = command.match(/^([a-zA-Z-]+):\s*(.*)/)) {
+        } else if ((match = command.match(/^([a-zA-Z-]+):\s*(.*)/))) {
             if (match[2]) {
                 this.headers[match[1]] = match[2];
             } else {
@@ -210,7 +212,7 @@ this.Console.prototype = new(function () {
             if (command.length > 0) {
               parts = command[0].split("?");
               if (parts[0]) {
-                path.push(parts[0])
+                path.push(parts[0]);
               }
             }
 
@@ -230,21 +232,24 @@ this.Console.prototype = new(function () {
                     });
                 }).end();
             }
-            return;
+            prompt = false;
         } else if (command) {
             util.puts(("unknown command '" + command + "'").yellow.bold);
         }
-        this.prompt();
+
+        if (prompt) {
+            this.prompt();
+        }
     };
     this.printResponse = function (res, body, callback) {
         var status = ('HTTP/' + res.httpVersion +
                       ' '     + res.statusCode  +
                       ' '     + http.STATUS_CODES[res.statusCode]).bold, output;
 
-        if      (res.statusCode >= 500) { status = status.red }
-        else if (res.statusCode >= 400) { status = status.yellow }
-        else if (res.statusCode >= 300) { status = status.cyan }
-        else                            { status = status.green }
+        if      (res.statusCode >= 500) { status = status.red; }
+        else if (res.statusCode >= 400) { status = status.yellow; }
+        else if (res.statusCode >= 300) { status = status.cyan; }
+        else                            { status = status.green; }
 
         util.puts(status);
 
@@ -252,8 +257,8 @@ this.Console.prototype = new(function () {
 
         util.print('\n');
 
-        try       { output = JSON.parse(body) }
-        catch (_) { output = body.trim() }
+        try       { output = JSON.parse(body); }
+        catch (_) { output = body.trim(); }
 
         if (typeof(output) === 'string') {
             output.length > 0 && util.print(output.white + '\n');

--- a/lib/http-console.js
+++ b/lib/http-console.js
@@ -120,7 +120,7 @@ this.Console.prototype = new(function () {
         }
     };
     this.exec = function (command) {
-        var method, headers = {}, path = this.path, body,
+        var method, headers = {}, path = this.path, parts, body,
             that = this,
             match, req;
 
@@ -196,9 +196,18 @@ this.Console.prototype = new(function () {
             method  = command.shift().toUpperCase();
             path    = this.path.slice(0);
 
-            if (command.length > 0) { path.push(command[0]) }
+            if (command.length > 0) {
+              parts = command[0].split("?");
+              if (parts[0]) {
+                path.push(parts[0])
+              }
+            }
 
             path = ('/' + path.join('/')).replace(/\/+/g, '/');
+
+            if (parts && parts[1]) {
+              path += '?' + parts[1];
+            }
 
             if (method === 'PUT' || method === 'POST') {
                 this.pending = { method: method, path: path };


### PR DESCRIPTION
This is pretty useful for querying against our REST API! However I had to add a few features to make it worthwhile:
- `--config` option (path to a config file) that is executed in the REPL. Lets you set headers, change the path, etc, though not execute requests.
- Support `GET ?foo=bar`
- Support `PATCH`

And some small fixes:
- Use `JSON.parse` to extract the version from `package.json`
- Linting fixes
- Ignore `node_modules`
